### PR TITLE
fix: respect bundled pip in cflinuxfs4

### DIFF
--- a/bin/bootstrap-python
+++ b/bin/bootstrap-python
@@ -39,7 +39,12 @@ then
 fi
 
 echo " ---> Bootstrapping pip..."
-PIP_CMD="pip"
+if [ "$CF_STACK" == "cflinuxfs4" ]; then
+  PIP_CMD="pip3"
+else
+  PIP_CMD="pip"
+fi
+
 if ! [[ -x "$(command -v ${PIP_CMD})" ]]
 then
     # pip is not included on the root FS
@@ -55,6 +60,9 @@ then
     PIP_CMD="/home/vcap/.local/bin/pip"
 else
     # pip is bundled on the root FS
+    if [ "$CF_STACK" == "cflinuxfs4" ]; then
+      PIP_CMD="python3 $(dirname "$(command -v python3)")/pip3"
+    fi
     $PIP_CMD install --upgrade --user --no-warn-script-location pip setuptools wheel
 fi
 


### PR DESCRIPTION
`pip3` executable is already available when installing Python in `cflinuxfs4` environment, but wasn't used by `bootstrap-python` script.

Also `python` distribution that we are downloading is having an incorrect shebang value:
```
> cat bin/pip3| head -1
#!/tmp/d20230208-8-z59c3j/bin/python3.10
```
This commit includes a fix to use a full path when invoking `pip3` in `cflinuxfs4` environment.